### PR TITLE
fix closing self.open_spi_handles

### DIFF
--- a/pipyadc/pipyadc.py
+++ b/pipyadc/pipyadc.py
@@ -187,7 +187,7 @@ class ADS1256():
     def stop_close_all(self):
         """Close all open pigpio SPI handles and stop pigpio connection
         """
-        for handle in reversed(self.open_spi_handles):
+        for handle in reversed(list(self.open_spi_handles.values())):
             logger.debug(f"Closing SPI handle: {handle}")
             self.pi.spi_close(handle)
         self.open_spi_handles.clear()


### PR DESCRIPTION
self.open_spi_handles looks like this: {7: 7}

calling reversed(self.open_spi_handles) throws:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: 'dict' object is not reversible